### PR TITLE
62 stability type refactoring

### DIFF
--- a/src/algmatch/abstractClasses/stabilityType.py
+++ b/src/algmatch/abstractClasses/stabilityType.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+class StabilityType(Enum):
+    STRONG = "strong"
+    SUPER = "super"
+    WEAK = "weak"
+
+    @classmethod
+    def from_value(cls, value: str):
+        if not isinstance(value, str):
+            raise ValueError(f"Expected stability type to be str: {value}")
+        value = value.lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        raise ValueError("Stability type ttype must be 'super', 'strong', or 'weak'")

--- a/src/algmatch/hospitalResidentsProblemWithTies.py
+++ b/src/algmatch/hospitalResidentsProblemWithTies.py
@@ -16,12 +16,18 @@ from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtSuperResidentOpti
 from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtSuperHospitalOptimal import (
     HRTSuperHospitalOptimal,
 )
-from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtAbstract import (
-    HRTAbstract,
-)
+
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HospitalResidentsProblemWithTies:
+    algorithms = {
+        (StabilityType.SUPER, "residents"): HRTSuperResidentOptimal,
+        (StabilityType.SUPER, "hospitals"): HRTSuperHospitalOptimal,
+        (StabilityType.STRONG, "residents"): HRTStrongResidentOptimal,
+        (StabilityType.STRONG, "hospitals"): HRTStrongHospitalOptimal,
+    }
+
     def __init__(
         self,
         filename: str | None = None,
@@ -35,7 +41,7 @@ class HospitalResidentsProblemWithTies:
         :param filename: str, optional, default=None, the path to the file to read in the preferences from.
         :param dictionary: dict, optional, default=None, the dictionary of preferences.
         :param optimised_side: str, optional, default="residents", whether the algorithm is "residents" (default) or "hospitals" sided.
-        :param stability_type: str, default=None, specifies the stability condition to be solved for.
+        :param stability_type_str: str, default=None, specifies the stability condition to be solved for.
         """
         if filename is not None:
             filename = os.path.join(os.getcwd(), filename)
@@ -53,38 +59,22 @@ class HospitalResidentsProblemWithTies:
         )
 
     def _validate_and_save_parameters(
-        self, filename, dictionary, optimised_side, stability_type
+        self, filename, dictionary, optimised_side, stability_type_str
     ):
         self._assert_valid_optimised_side(optimised_side)
         self.optimised_side = optimised_side.lower()
-
-        HRTAbstract._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
+        self.stability_type = StabilityType.from_value(stability_type_str)
         self.filename = filename
         self.dictionary = dictionary
 
     def _set_algorithm(self):
-        if self.stability_type == "super":
-            if self.optimised_side == "residents":
-                self.hr_alg = HRTSuperResidentOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-            else:
-                self.hr_alg = HRTSuperHospitalOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-        elif self.stability_type == "strong":
-            if self.optimised_side == "residents":
-                self.hr_alg = HRTStrongResidentOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-            else:
-                self.hr_alg = HRTStrongHospitalOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-        else:
-            raise ValueError('stability_type must be either "strong" or "super".')
+        alg_key = (self.stability_type, self.optimised_side)
+        if alg_key not in self.algorithms:
+            raise NotImplementedError(
+                "No algorithm has been implemented for this case."
+            )
+        alg_class = self.algorithms[alg_key]
+        self.hr_alg = alg_class(filename=self.filename, dictionary=self.dictionary)
 
     def get_stable_matching(self) -> dict | None:
         """

--- a/src/algmatch/hospitalResidentsProblemWithTies.py
+++ b/src/algmatch/hospitalResidentsProblemWithTies.py
@@ -41,7 +41,7 @@ class HospitalResidentsProblemWithTies:
         :param filename: str, optional, default=None, the path to the file to read in the preferences from.
         :param dictionary: dict, optional, default=None, the dictionary of preferences.
         :param optimised_side: str, optional, default="residents", whether the algorithm is "residents" (default) or "hospitals" sided.
-        :param stability_type_str: str, default=None, specifies the stability condition to be solved for.
+        :param stability_type: str, default=None, specifies the stability condition to be solved for.
         """
         if filename is not None:
             filename = os.path.join(os.getcwd(), filename)

--- a/src/algmatch/stableMarriageProblemWithTies.py
+++ b/src/algmatch/stableMarriageProblemWithTies.py
@@ -15,10 +15,18 @@ from algmatch.stableMatchings.stableMarriageProblem.ties.smtStrongManOptimal imp
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtStrongWomanOptimal import (
     SMTStrongWomanOptimal,
 )
-from algmatch.stableMatchings.stableMarriageProblem.ties.smtAbstract import SMTAbstract
+
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class StableMarriageProblemWithTies:
+    algorithms = {
+        (StabilityType.SUPER, "men"): SMTSuperManOriented,
+        (StabilityType.SUPER, "women"): SMTSuperWomanOriented,
+        (StabilityType.STRONG, "men"): SMTStrongManOptimal,
+        (StabilityType.STRONG, "women"): SMTStrongWomanOptimal,
+    }
+
     def __init__(
         self,
         filename: str | None = None,
@@ -44,43 +52,28 @@ class StableMarriageProblemWithTies:
 
     def _assert_valid_optimised_side(self, optimised_side):
         assert type(optimised_side) is str, "Param optimised_side must be of type str"
+        optimised_side = optimised_side.lower()
         assert optimised_side in ("men", "women"), (
             "Optimised side must either be 'men' or 'women'"
         )
 
     def _validate_and_save_parameters(
-        self, filename, dictionary, optimised_side, stability_type
+        self, filename, dictionary, optimised_side, stability_type_str
     ):
         self._assert_valid_optimised_side(optimised_side)
         self.optimised_side = optimised_side.lower()
-
-        SMTAbstract._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
+        self.stability_type = StabilityType.from_value(stability_type_str)
         self.filename = filename
         self.dictionary = dictionary
 
     def _set_algorithm(self):
-        if self.stability_type == "super":
-            if self.optimised_side == "men":
-                self.sm_alg = SMTSuperManOriented(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-            else:
-                self.sm_alg = SMTSuperWomanOriented(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-        elif self.stability_type == "strong":
-            if self.optimised_side == "men":
-                self.sm_alg = SMTStrongManOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-            else:
-                self.sm_alg = SMTStrongWomanOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-        else:
-            raise ValueError('stability_type must be either "strong" or "super".')
+        alg_key = (self.stability_type, self.optimised_side)
+        if alg_key not in self.algorithms:
+            raise NotImplementedError(
+                "No algorithm has been implemented for this case."
+            )
+        alg_class = self.algorithms[alg_key]
+        self.sm_alg = alg_class(filename=self.filename, dictionary=self.dictionary)
 
     def get_stable_matching(self) -> dict | None:
         """

--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtAbstract.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtAbstract.py
@@ -239,7 +239,7 @@ class HRTAbstract:
             self.save_resident_sided()
             self.save_hospital_sided()
 
-            if self.stability_type == "super":
+            if self.stability_type == StabilityType.SUPER:
                 self.is_stable = self._check_super_stability()
             else:
                 self.is_stable = self._check_strong_stability()

--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtAbstract.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtAbstract.py
@@ -8,6 +8,7 @@ import os
 from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtPreferenceInstance import (
     HRTPreferenceInstance,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HRTAbstract:
@@ -15,7 +16,7 @@ class HRTAbstract:
         self,
         filename: str | None = None,
         dictionary: dict | None = None,
-        stability_type: str = None,
+        stability_type: StabilityType = None,
     ) -> None:
         assert filename is not None or dictionary is not None, (
             "Either filename or dictionary must be provided"
@@ -24,15 +25,14 @@ class HRTAbstract:
             "Only one of filename or dictionary must be provided"
         )
 
-        self._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
         if filename is not None:
             assert os.path.isfile(filename), f"File {filename} does not exist"
             self._reader = HRTPreferenceInstance(filename=filename)
 
         if dictionary is not None:
             self._reader = HRTPreferenceInstance(dictionary=dictionary)
+
+        self.stability_type = stability_type
 
         self.residents = self._reader.residents
         self.hospitals = self._reader.hospitals
@@ -46,14 +46,6 @@ class HRTAbstract:
             "hospital_sided": {h: set() for h in self.hospitals},
         }
         self.is_stable = False
-
-    @staticmethod
-    def _assert_valid_stability_type(st) -> None:
-        assert st is not None, "Select a stability type - either 'super' or 'strong'"
-        assert type(st) is str, "Stability type is not str'"
-        assert st.lower() in ("super", "strong"), (
-            "Stability type must be either 'super' or 'strong'"
-        )
 
     def _get_worst_existing_resident(self, hospital):
         existing_residents = self.M[hospital]["assigned"]

--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtStrongAbstract.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtStrongAbstract.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtAbstract import (
     HRTAbstract,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HRTStrongAbstract(HRTAbstract):
@@ -19,7 +20,9 @@ class HRTStrongAbstract(HRTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="strong"
+            filename=filename,
+            dictionary=dictionary,
+            stability_type=StabilityType.STRONG,
         )
         # used to find the critical set and final answer
         self.maximum_matching = {}

--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtSuperHospitalOptimal.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtSuperHospitalOptimal.py
@@ -5,6 +5,7 @@ Algorithm to produce M_0, the hospital-optimal, resident-pessimal super-stable m
 from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtAbstract import (
     HRTAbstract,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HRTSuperHospitalOptimal(HRTAbstract):
@@ -12,7 +13,7 @@ class HRTSuperHospitalOptimal(HRTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="super"
+            filename=filename, dictionary=dictionary, stability_type=StabilityType.SUPER
         )
 
         self.undersub_hospitals = set()

--- a/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtSuperResidentOptimal.py
+++ b/src/algmatch/stableMatchings/hospitalResidentsProblem/ties/hrtSuperResidentOptimal.py
@@ -5,6 +5,7 @@ Algorithm to produce M_0, the resident-optimal, hospital-pessimal super-stable m
 from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtAbstract import (
     HRTAbstract,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HRTSuperResidentOptimal(HRTAbstract):
@@ -12,7 +13,7 @@ class HRTSuperResidentOptimal(HRTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="super"
+            filename=filename, dictionary=dictionary, stability_type=StabilityType.SUPER
         )
 
         self.unassigned_residents = set()

--- a/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtAbstract.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtAbstract.py
@@ -232,7 +232,7 @@ class SMTAbstract:
             self.save_man_sided()
             self.save_woman_sided()
 
-            if self.stability_type == "super":
+            if self.stability_type == StabilityType.SUPER:
                 self.is_stable = self._check_super_stability()
             else:
                 self.is_stable = self._check_strong_stability()

--- a/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtAbstract.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtAbstract.py
@@ -8,6 +8,7 @@ import os
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtPreferenceInstance import (
     SMTPreferenceInstance,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SMTAbstract:
@@ -15,7 +16,7 @@ class SMTAbstract:
         self,
         filename: str | None = None,
         dictionary: dict | None = None,
-        stability_type: str = None,
+        stability_type: StabilityType = None,
     ) -> None:
         assert filename is not None or dictionary is not None, (
             "Either filename or dictionary must be provided"
@@ -24,15 +25,14 @@ class SMTAbstract:
             "Only one of filename or dictionary must be provided"
         )
 
-        self._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
         if filename is not None:
             assert os.path.isfile(filename), f"File {filename} does not exist"
             self._reader = SMTPreferenceInstance(filename=filename)
 
         if dictionary is not None:
             self._reader = SMTPreferenceInstance(dictionary=dictionary)
+
+        self.stability_type = stability_type
 
         self.men = self._reader.men
         self.women = self._reader.women
@@ -46,14 +46,6 @@ class SMTAbstract:
             "woman_sided": {w: "" for w in self.women},
         }
         self.is_stable = False
-
-    @staticmethod
-    def _assert_valid_stability_type(st) -> None:
-        assert st is not None, "Select a stability type - either 'super' or 'strong'"
-        assert type(st) is str, "Stability type is not str'"
-        assert st.lower() in ("super", "strong"), (
-            "Stability type must be either 'super' or 'strong'"
-        )
 
     def _check_super_stability(self) -> bool:
         # first check for multiple-assignment

--- a/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtStrongAbstract.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtStrongAbstract.py
@@ -6,6 +6,7 @@ Stores Hopcroft-Karp implementation for finding the maximum matching
 from collections import deque
 
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtAbstract import SMTAbstract
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SMTStrongAbstract(SMTAbstract):
@@ -13,7 +14,9 @@ class SMTStrongAbstract(SMTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="strong"
+            filename=filename,
+            dictionary=dictionary,
+            stability_type=StabilityType.STRONG,
         )
         # used to find the critical set and final answer
         self.maximum_matching = {}

--- a/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtSuperManOriented.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtSuperManOriented.py
@@ -3,6 +3,7 @@ Algorithm to produce M_0, the man-optimal, woman-pessimal super-stable matching,
 """
 
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtAbstract import SMTAbstract
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SMTSuperManOriented(SMTAbstract):
@@ -10,7 +11,7 @@ class SMTSuperManOriented(SMTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="super"
+            filename=filename, dictionary=dictionary, stability_type=StabilityType.SUPER
         )
 
         self.unassigned_men = set()

--- a/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtSuperWomanOriented.py
+++ b/src/algmatch/stableMatchings/stableMarriageProblem/ties/smtSuperWomanOriented.py
@@ -3,6 +3,7 @@ Algorithm to produce M_z, the woman-optimal, man-pessimal super-stable matching,
 """
 
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtAbstract import SMTAbstract
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SMTSuperWomanOriented(SMTAbstract):
@@ -10,7 +11,7 @@ class SMTSuperWomanOriented(SMTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="super"
+            filename=filename, dictionary=dictionary, stability_type=StabilityType.SUPER
         )
 
         self.unassigned_women = set()

--- a/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastAbstract.py
+++ b/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastAbstract.py
@@ -10,6 +10,7 @@ import os
 from algmatch.stableMatchings.studentProjectAllocation.ties.spastPreferenceInstance import (
     SPASTPreferenceInstance,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SPASTAbstract:
@@ -17,7 +18,7 @@ class SPASTAbstract:
         self,
         filename: str | None = None,
         dictionary: dict | None = None,
-        stability_type: str = None,
+        stability_type: StabilityType = None,
     ) -> None:
         assert filename is not None or dictionary is not None, (
             "Either filename or dictionary must be provided"
@@ -26,15 +27,14 @@ class SPASTAbstract:
             "Only one of filename or dictionary must be provided"
         )
 
-        self._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
         if filename is not None:
             assert os.path.isfile(filename), f"File {filename} does not exist"
             self._reader = SPASTPreferenceInstance(filename=filename)
 
         if dictionary is not None:
             self._reader = SPASTPreferenceInstance(dictionary=dictionary)
+
+        self.stability_type = stability_type
 
         self.students = self._reader.students
         self.projects = self._reader.projects
@@ -56,14 +56,6 @@ class SPASTAbstract:
             self._blocking_pair_biii,
         )
         self.is_stable = False
-
-    @staticmethod
-    def _assert_valid_stability_type(st) -> None:
-        assert st is not None, "Select a stability type - either 'super' or 'strong'"
-        assert type(st) is str, "Stability type is not str'"
-        assert st.lower() in ("super", "strong"), (
-            "Stability type must be either 'super' or 'strong'"
-        )
 
     def _get_lecturer_worst_existing_student(self, lecturer):
         existing_students = self.M[lecturer]["assigned"]

--- a/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastAbstract.py
+++ b/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastAbstract.py
@@ -298,7 +298,7 @@ class SPASTAbstract:
             self._save_student_sided()
             self._save_lecturer_sided()
 
-            if self.stability_type == "super":
+            if self.stability_type == StabilityType.SUPER:
                 self.is_stable = self._check_super_stability()
             else:
                 self.is_stable = self._check_strong_stability()

--- a/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastSuperStudentOptimal.py
+++ b/src/algmatch/stableMatchings/studentProjectAllocation/ties/spastSuperStudentOptimal.py
@@ -5,6 +5,7 @@ Algorithm to produce M_0, the student-optimal, lecturer-pessimal super-stable ma
 from algmatch.stableMatchings.studentProjectAllocation.ties.spastAbstract import (
     SPASTAbstract,
 )
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SPASTSuperStudentOptimal(SPASTAbstract):
@@ -12,7 +13,7 @@ class SPASTSuperStudentOptimal(SPASTAbstract):
         self, filename: str | None = None, dictionary: dict | None = None
     ) -> None:
         super().__init__(
-            filename=filename, dictionary=dictionary, stability_type="super"
+            filename=filename, dictionary=dictionary, stability_type=StabilityType.SUPER
         )
 
         self.unassigned_students = set()

--- a/src/algmatch/studentProjectAllocationWithTies.py
+++ b/src/algmatch/studentProjectAllocationWithTies.py
@@ -7,12 +7,15 @@ import os
 from algmatch.stableMatchings.studentProjectAllocation.ties.spastSuperStudentOptimal import (
     SPASTSuperStudentOptimal,
 )
-from algmatch.stableMatchings.studentProjectAllocation.ties.spastAbstract import (
-    SPASTAbstract,
-)
+
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
-class StudentProjectAllocationWithTies:
+class StudentProjectAllocationWithTies:  #
+    algorithms = {
+        (StabilityType.SUPER, "students"): SPASTSuperStudentOptimal,
+    }
+
     def __init__(
         self,
         filename: str | None = None,
@@ -48,27 +51,18 @@ class StudentProjectAllocationWithTies:
     ):
         self._assert_valid_optimised_side(optimised_side)
         self.optimised_side = optimised_side.lower()
-
-        SPASTAbstract._assert_valid_stability_type(stability_type)
-        self.stability_type = stability_type.lower()
-
+        self.stability_type = StabilityType.from_value(stability_type)
         self.filename = filename
         self.dictionary = dictionary
 
     def _set_algorithm(self):
-        if self.stability_type == "super":
-            if self.optimised_side == "students":
-                self.spas_alg = SPASTSuperStudentOptimal(
-                    filename=self.filename, dictionary=self.dictionary
-                )
-            else:
-                raise NotImplementedError(
-                    "Lecturer oriented algorithms are not yet available."
-                )
-        elif self.stability_type == "strong":
-            raise NotImplementedError("Strong algorithms are not yet available.")
-        else:
-            raise ValueError('stability_type must be either "strong" or "super".')
+        alg_key = (self.stability_type, self.optimised_side)
+        if alg_key not in self.algorithms:
+            raise NotImplementedError(
+                "No algorithm has been implemented for this case."
+            )
+        alg_class = self.algorithms[alg_key]
+        self.spas_alg = alg_class(filename=self.filename, dictionary=self.dictionary)
 
     def get_stable_matching(self) -> dict | None:
         """

--- a/src/algmatch/utils/enumerators/HR/hrtEnumerator.py
+++ b/src/algmatch/utils/enumerators/HR/hrtEnumerator.py
@@ -2,20 +2,22 @@ from algmatch.stableMatchings.hospitalResidentsProblem.ties.hrtAbstract import (
     HRTAbstract,
 )
 from algmatch.utils.enumerators.HR.hrGenericEnumerator import HRGenericEnumerator
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class HRTEnumerator(HRTAbstract, HRGenericEnumerator):
     def __init__(self, dictionary, stability_type):
+        stability_type = StabilityType.from_value(stability_type)
         HRTAbstract.__init__(self, dictionary=dictionary, stability_type=stability_type)
         HRGenericEnumerator.__init__(self)
 
     def has_stability(self) -> bool:
-        if self.stability_type == "super":
+        if self.stability_type == StabilityType.SUPER:
             return self._check_super_stability()
-        elif self.stability_type == "strong":
+        elif self.stability_type == StabilityType.STRONG:
             return self._check_strong_stability()
         else:
-            raise ValueError("Stability type is neither 'super' or 'strong'")
+            raise ValueError("Stability type is neither 'super' nor 'strong'")
 
     def resident_trial_order(self, resident):
         for tie in self.residents[resident]["list"]:

--- a/src/algmatch/utils/enumerators/SM/smtEnumerator.py
+++ b/src/algmatch/utils/enumerators/SM/smtEnumerator.py
@@ -1,16 +1,18 @@
 from algmatch.stableMatchings.stableMarriageProblem.ties.smtAbstract import SMTAbstract
 from algmatch.utils.enumerators.SM.smGenericEnumerator import SMGenericEnumerator
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SMTEnumerator(SMTAbstract, SMGenericEnumerator):
     def __init__(self, dictionary, stability_type):
+        stability_type = StabilityType.from_value(stability_type)
         SMTAbstract.__init__(self, dictionary=dictionary, stability_type=stability_type)
         SMGenericEnumerator.__init__(self)
 
     def has_stability(self) -> bool:
-        if self.stability_type == "super":
+        if self.stability_type == StabilityType.SUPER:
             return self._check_super_stability()
-        elif self.stability_type == "strong":
+        elif self.stability_type == StabilityType.STRONG:
             return self._check_strong_stability()
         else:
             raise ValueError("Stability type is neither 'super' or 'strong'")

--- a/src/algmatch/utils/enumerators/SM/smtEnumerator.py
+++ b/src/algmatch/utils/enumerators/SM/smtEnumerator.py
@@ -15,7 +15,7 @@ class SMTEnumerator(SMTAbstract, SMGenericEnumerator):
         elif self.stability_type == StabilityType.STRONG:
             return self._check_strong_stability()
         else:
-            raise ValueError("Stability type is neither 'super' or 'strong'")
+            raise ValueError("Stability type is neither 'super' nor 'strong'")
 
     def man_trial_order(self, man):
         for tie in self.men[man]["list"]:

--- a/src/algmatch/utils/enumerators/SPAS/spastEnumerator.py
+++ b/src/algmatch/utils/enumerators/SPAS/spastEnumerator.py
@@ -2,22 +2,24 @@ from algmatch.stableMatchings.studentProjectAllocation.ties.spastAbstract import
     SPASTAbstract,
 )
 from algmatch.utils.enumerators.SPAS.spasGenericEnumerator import SPASGenericEnumerator
+from algmatch.abstractClasses.stabilityType import StabilityType
 
 
 class SPASTEnumerator(SPASTAbstract, SPASGenericEnumerator):
     def __init__(self, dictionary, stability_type):
+        stability_type = StabilityType.from_value(stability_type)
         SPASTAbstract.__init__(
             self, dictionary=dictionary, stability_type=stability_type
         )
         SPASGenericEnumerator.__init__(self)
 
     def has_stability(self):
-        if self.stability_type == "super":
+        if self.stability_type == StabilityType.SUPER:
             return self._check_super_stability()
-        elif self.stability_type == "strong":
+        elif self.stability_type == StabilityType.STRONG:
             return self._check_strong_stability()
         else:
-            raise ValueError("Stability type is neither 'super' or 'strong'")
+            raise ValueError("Stability type is neither 'super' nor 'strong'")
 
     def student_trial_order(self, student):
         for tie in self.students[student]["list"]:

--- a/tests/SPASTests/SPASTSuper/spastSuperSingleVerifier.py
+++ b/tests/SPASTests/SPASTSuper/spastSuperSingleVerifier.py
@@ -35,11 +35,11 @@ class SPASTSuperSingleVerifier(SPASTSuperVerifier, AbstractSingleVerifier):
 
 
 def main():
-    TOTAL_STUDENTS = 12
-    TOTAL_PROJECTS = 5
-    TOTAL_LECTURERS = 3
+    TOTAL_STUDENTS = 7
+    TOTAL_PROJECTS = 4
+    TOTAL_LECTURERS = 2
     LOWER_BOUND = 0
-    UPPER_BOUND = 3
+    UPPER_BOUND = 4
     TIE_DENSITY_STEPS = 10
     REPS_PER_TDS = 5_000
 


### PR DESCRIPTION
Introduces the StabililtyType enum to replace the use of raw strings for stability type data through the codebase.
This enum has a from_value method which removes the need for the repeated function which validates the user input.